### PR TITLE
Change `--issue-limit` to type Int and default to None

### DIFF
--- a/scripts/create-issue.py
+++ b/scripts/create-issue.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--username", default="opencdms", required=False)
     parser.add_argument("--repo", default="temp-repo", required=False)
-    parser.add_argument("--issue-limit", default=1, required=False)
+    parser.add_argument("--issue-limit", default=None, type=int, required=False)
     parser.add_argument(
         "--common-labels", default=["Epic", "CDMS v1.0"], required=False
     )


### PR DESCRIPTION
This was to fix the following bug, due to `issue-limit` being of type str and also allow all issues to be created together by setting default to None

```
Traceback (most recent call last):
  File "create-issue.py", line 170, in <module>
    for issue in issues_to_create[: args.issue_limit]:
TypeError: slice indices must be integers or None or have an __index__ method
```